### PR TITLE
fixed some issues regarding the 'release-drafter' config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -89,28 +89,23 @@ header: ''
 footer: ''
 
 change-title-escapes: '\<*_&'
-change-template: '- [(#$NUMBER)]($URL) $TITLE by [$AUTHOR](https://github.com/$AUTHOR)'
+change-template: '- ([#$NUMBER]($URL)) $TITLE by [@$AUTHOR](https://github.com/$AUTHOR)'
 no-changes-template: '- No changes'
 category-template: |
   ## $TITLE
 
-  $CHANGES
-
 template: |
-  # v$RESOLVED_VERSION
+  These are the release notes for v$RESOLVED_VERSION:
 
   $CHANGES
+
+  ## Previous Release
+
+  You can see [the full changelog](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION), [all releases](https://github.com/$OWNER/$REPOSITORY/releases/), or [the previous release ($PREVIOUS_TAG)](https://github.com/$OWNER/$REPOSITORY/releases/tag/$PREVIOUS_TAG) on GitHub.
 
   ## Contributors
 
   A big thanks to all contributors who helped with this release: $CONTRIBUTORS
-
-  ## Previous Release
-
-  You can see [the full changelog](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION),
-  [all releases](https://github.com/$OWNER/$REPOSITORY/releases/),
-  or [the previous release $PREVIOUS_TAG](https://github.com/$OWNER/$REPOSITORY/releases/tag/$PREVIOUS_TAG) on GitHub.
-
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 


### PR DESCRIPTION
Some issues were:
- The 'change-template' put the parentheses within the link when it should be only the contents within.
- The paragraph on previous releases was broken up on different lines. Obviously this should not be the case.
- Moved the thanks to all contributors to the bottom as that is also were Github puts their pictures.