### PR TITLE
Fixed a missing 'version' env var in a github action workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -89,28 +89,23 @@ header: ''
 footer: ''
 
 change-title-escapes: '\<*_&'
-change-template: '- [(#$NUMBER)]($URL) $TITLE by [$AUTHOR](https://github.com/$AUTHOR)'
+change-template: '- ([#$NUMBER]($URL)) $TITLE by [@$AUTHOR](https://github.com/$AUTHOR)'
 no-changes-template: '- No changes'
 category-template: |
   ## $TITLE
 
-  $CHANGES
-
 template: |
-  # v$RESOLVED_VERSION
+  These are the release notes for v$RESOLVED_VERSION:
 
   $CHANGES
+
+  ## Previous Release
+
+  You can see [the full changelog](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION), [all releases](https://github.com/$OWNER/$REPOSITORY/releases/), or [the previous release ($PREVIOUS_TAG)](https://github.com/$OWNER/$REPOSITORY/releases/tag/$PREVIOUS_TAG) on GitHub.
 
   ## Contributors
 
   A big thanks to all contributors who helped with this release: $CONTRIBUTORS
-
-  ## Previous Release
-
-  You can see [the full changelog](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION),
-  [all releases](https://github.com/$OWNER/$REPOSITORY/releases/),
-  or [the previous release $PREVIOUS_TAG](https://github.com/$OWNER/$REPOSITORY/releases/tag/$PREVIOUS_TAG) on GitHub.
-
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,6 +23,7 @@ jobs:
         id: build-packages-from-flake
         run: |
           mkdir --parents artifacts
+          version="${{ github.ref_name }}"
           system=$(nix eval --impure --expr 'builtins.currentSystem' --json | jq -r .)
           mkdir --parents artifacts
           echo "building for ${system}:"
@@ -40,7 +41,7 @@ jobs:
           tag: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Upload Release Asset
         id: upload-release-asset
         uses: softprops/action-gh-release@v2.2.2


### PR DESCRIPTION
The workflow in question was `publish-release`. This is a part of that workflow:

```SH
mkdir --parents artifacts
system=$(nix eval --impure --expr 'builtins.currentSystem' --json | jq -r .)
mkdir --parents artifacts
echo "building for ${system}:"
for package in $(nix flake show --json | jq -r ".packages.\"${system}\" | keys[]"); do
  echo "Building package: ${package} (${system})"
  nix build .#${package}
  tar czf "artifacts/${package}-${version}-${system}.tar.gz" -C result .
  rm -rf result
done
```

note the version variable is missing. So I added it:

```SH
version="${{ github.ref_name }}"
```

Now that script in the workflow looks like this:

```SH
mkdir --parents artifacts
version="${{ github.ref_name }}"
system=$(nix eval --impure --expr 'builtins.currentSystem' --json | jq -r .)
mkdir --parents artifacts
echo "building for ${system}:"
for package in $(nix flake show --json | jq -r ".packages.\"${system}\" | keys[]"); do
  echo "Building package: ${package} (${system})"
  nix build .#${package}
  tar czf "artifacts/${package}-${version}-${system}.tar.gz" -C result .
  rm -rf result
done
```