### PR TITLE
Close #14: Make release workflow also copy nix result directory

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,14 +23,24 @@ jobs:
         id: build-packages-from-flake
         run: |
           mkdir --parents artifacts
+
           version="${{ github.ref_name }}"
           system=$(nix eval --impure --expr 'builtins.currentSystem' --json | jq -r .)
-          mkdir --parents artifacts
+
           echo "building for ${system}:"
           for package in $(nix flake show --json | jq -r ".packages.\"${system}\" | keys[]"); do
+
             echo "Building package: ${package} (${system})"
             nix build .#${package}
+
             tar czf "artifacts/${package}-${version}-${system}.tar.gz" -C result .
+
+            if [ -d result ]; then
+              cp result/ artifacts/${package}-${version}-${system}/ --recursive
+            else
+              cp result artifacts/${package}-${version}-${system}
+            fi
+
             rm -rf result
           done
 
@@ -48,7 +58,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_unmatched_files: true
-          files: 'artifacts/**/*.tar.gz'
+          files: | # globs to files you want to upload:
+            artifacts/**/*.tar.gz
+            artifacts/**/*.pdf
+            artifacts/**/*.stl
           # Do not change the body
           append_body: true
           body: ''


### PR DESCRIPTION
Made the publish release workflow also copy the nix result directory into the artifact directory. This allows for the ability of the artifact publisher to search for files in the result directory.

A very clear use case is: let's say that the build produces a PDF. Now when you create a release you want the PDF to be a artifact that can be downloaded, not a tarball that has to be decompressed and then searched. That is not good UX. This solves that problem as the workflow can now publish any file within the artifact directory that matches the provided globs.