### PR TITLE
Made release notes use tables instead of lists

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -89,11 +89,13 @@ header: ''
 footer: ''
 
 change-title-escapes: '\<*_&'
-change-template: '- #$NUMBER $TITLE by @$AUTHOR'
-no-changes-template: '- No changes'
+change-template: '| #$NUMBER | @$AUTHOR | $TITLE |'
+no-changes-template: 'No changes yet...'
 category-template: |
   ## $TITLE
 
+  | PR | Author | title |
+  |----|--------|-------|
 template: |
   These are the release notes for v$RESOLVED_VERSION:
 


### PR DESCRIPTION
This is because the tables are alot more readable then the lists.