### PR TITLE
Fixed an issue with failing labeler

### DIFF
--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -1,6 +1,6 @@
 name: PR Labeler
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     branches:
       - main
@@ -17,4 +17,5 @@ jobs:
     - name: Label Pull Request
       uses: actions/labeler@v5
       with:
+        sync-labels: true
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There is an issue where the labeler fails with:

```txt
The configuration file (path: .github/labeler.yml) was found locally, reading from the file
Error: HttpError: You do not have permission to create labels on this repository.
{"resource":"Repository","field":"label","code":"unauthorized"}
Error: You do not have permission to create labels on this repository.
{"resource":"Repository","field":"label","code":"unauthorized"}
```

The labeler makers said the following in their readme:

> In order to add labels to pull requests, the GitHub labeler action requires write permissions on the pull-request. However, when the action runs on a pull request from a forked repository, GitHub only grants read access tokens for `pull_request` events, at most. If you encounter an `Error: HttpError: Resource not accessible by integration`, it's likely due to these permission constraints. To resolve this issue, you can modify the `on:` section of your workflow to use `pull_request_target` instead of `pull_request`. This change allows the action to have write access, because `pull_request_target` alters the context of the action for more details about access levels and event contexts.
>
> ```yml
>     permissions:
>       contents: read
>       pull-requests: write
> ```