### PR TITLE
Fixes failing labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,7 +11,7 @@ documentation:
     - '^documentation\/'
     - '^docs\/'
 
-feature:
+enhancement:
   - head-branch:
     - '^feature\/'
     - '^feat\/'


### PR DESCRIPTION
The PR of #29, #36 did not actually work. I think the issue was that it tried to create the 'feature' label but it does not have the permissions so it failed. Instead it should use the existing 'enhancement' label.