### PR TITLE
Added an update-flake-lock workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -20,7 +20,3 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@v25
         with:
           nix-options: --debug --log-format raw
-      - name: Auto-merge just created PR
-        run: gh pr merge ${{ steps.update.update-flake-lock.pull-request-number }} --merge --admin --delete-branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I added this workflow to keep the flake.lock file up to date as 'flake-checker' seemed to have an issue with the flake.lock file being out of date. So now I can't push anymore on those branches without ignoring the commit hooks all together which defeats the entire purpose.

The error that prevents pushes:

```
Flake checker results:

The flake checker scanned your flake.lock and discovered 1 issue
that we recommend looking into:


>>> Outdated Nixpkgs dependencies

> The nixpkgs input is 32 days old

The maximum recommended age is 30 days.

>> What to do

For a more automated approach, use the update-flake-lock GitHub Action to create
create pull requests to update your flake.lock (if you're using Github Actions).

For a more ad hoc approach, use the nix flake update utility.

>> Why it's important to keep Nix dependencies up to date

Nixpkgs receives a continuous stream of security patches to keep your software
and systems secure. Using outdated revisions of Nixpkgs can inadvertently expose
you to software security risks that have been resolved in more recent releases.
```

See [the action they are referring to](https://github.com/DeterminateSystems/update-flake-lock). It is again a problem as I cannot verify that this works without merging it first.