### PR TITLE
Saved CI minutes

### DIFF
--- a/.github/workflows/enforce-branch-naming.yml
+++ b/.github/workflows/enforce-branch-naming.yml
@@ -2,7 +2,7 @@ name: Enforce branch naming
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened]
     branches:
       - main
 


### PR DESCRIPTION
The branch name cannot change or the PR will close, so if it fails on open, it will fail always. So we do not need to check subsequent events.