### PR TITLE
feat(pre-commit): enforce file is either empty or ends in new line

### DIFF
--- a/.config/pre-commit.nix
+++ b/.config/pre-commit.nix
@@ -122,6 +122,16 @@
       };
     };
 
+    # Ensures that a file is either empty, or ends with a single newline.
+    end-of-file-fixer = {
+      enable = true;
+      stages = [
+        "pre-push"
+        "pre-commit"
+        "manual"
+      ];
+    };
+
     # Checks markdown files for broken links, and bad syntax.
     mdformat = {
       enable = true;

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -108,5 +108,3 @@ template: |
   A big thanks to all contributors who helped with this release: $CONTRIBUTORS
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
-
-


### PR DESCRIPTION
POSIX defines a text file as a sequence of lines each ending with a newline, and many tools (like diff, cat, compilers, linters) assume this. Without it, it can cause:

- Incorrect diffs (shows fake changes)
- Concatenation issues (cat won’t separate files cleanly)
- Build or runtime warnings/errors in some languages