### PR TITLE
docs(readme): added issue labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 <br>
 <div align="center">
     <a href="https://github.com/codespaces/new?repo=school-Tygo-van-den-Hurk/template">
-      <img src="https://img.shields.io/badge/_-Open_in_GitHub_CodeSpace-2F363D.svg?labelColor=24292E&style=flat&logo=GitHub" alt="open in CodeSpaces"/>
+      <img src="https://img.shields.io/badge/_-Open_in_GitHub_CodeSpace-2F363D.svg?labelColor=24292E&style=flat&logo=GitHub&logoColor=959DA5" alt="open in CodeSpaces"/>
     </a>
     <a href="https://nixos.org">
       <img src="https://img.shields.io/badge/Built_With-Nix-5277C3.svg?style=flat&logo=nixos&labelColor=73C3D5" alt="Built with Nix"/>
     </a>
     <a href="https://containers.dev/">
-      <img src="https://img.shields.io/badge/devcontainer-provided-green?style=flat" alt="devcontainer provided"/>
+      <img src="https://img.shields.io/badge/devcontainer-provided-green?style=flat&logo=docker&logoColor=959DA5" alt="devcontainer provided"/>
     </a>
     <!--~ Repository CI/CD ~-->
     <a href="https://github.com/school-Tygo-van-den-Hurk/template/actions/workflows/deploy-github-pages.yml">
@@ -17,6 +17,13 @@
     </a>
     <a href="https://github.com/school-Tygo-van-den-Hurk/template/actions/workflows/nix-flake-check.yml">
       <img src="https://github.com/school-Tygo-van-den-Hurk/template/workflows/Nix%20Flake%20Checks/badge.svg?style=flat" alt="GitHub tests status" />
+    </a>
+    <!-- Open issues and PRs -->
+    <a href="https://github.com/school-Tygo-van-den-Hurk/template/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug">
+      <img src="https://img.shields.io/github/issues/school-Tygo-van-den-Hurk/template/bug?label=bug%20reports" alt="GitHub open bug reports"/>
+    </a>
+    <a href="https://github.com/school-Tygo-van-den-Hurk/template/issues?q=is%3Aissue%20state%3Aopen%20label%3Aenhancement">
+      <img src="https://img.shields.io/github/issues/school-Tygo-van-den-Hurk/template/enhancement?label=feature%20requests" alt="GitHub open feature requests"/>
     </a>
     <!--~ Repository Statistics ~-->
     <a href="https://github.com/school-Tygo-van-den-Hurk/template/graphs/contributors">


### PR DESCRIPTION
These labels reflect how many issues of a certain type are open. Examples are:

- open issues labeled "Bug" => bug report
- open issues labeled "Enhancement" => feature requests

These reflect how many issues a repository has.

examples:

<br>
<div align="center">
    <a href="https://github.com/school-Tygo-van-den-Hurk/template/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug">
      <img src="https://img.shields.io/github/issues/school-Tygo-van-den-Hurk/template/bug?label=bug%20reports" alt="GitHub open bug reports"/>
    </a>
    <a href="https://github.com/school-Tygo-van-den-Hurk/template/issues?q=is%3Aissue%20state%3Aopen%20label%3Aenhancement">
      <img src="https://img.shields.io/github/issues/school-Tygo-van-den-Hurk/template/enhancement?label=feature%20requests" alt="GitHub open feature requests"/>
    </a>
</div>
